### PR TITLE
Add options for including Skills, Dreamers, White Fragments, and Grubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@ In the mod menu, you can control when the UI is visible - always, while the game
 
 In the "All Major Items" connection submenu, you can configure the settings for a new rando save. If enabled, this will affect the hash, 
 so you can verify your settings are the same as everyone else you're playing with - using this mod is preferred for races rather than
-using HKSpoilerViewer. To play with default settings, you only need to enable the connection. Optionally, you can include unique keys 
+using HKSpoilerViewer.
+
+To play with default settings, you only need to enable the connection. Optionally, you can include grubs, unique keys 
 (e.g. Love Key and Elegant Key), key-like charms (Defender's Crest, Spore Shroom, and Grimmchild), and/or charm notches to add additional items to the tracker/objective as desired.
+You can also exclude skills, Dreamers and White Fragments, which are
+enabled by default.
 
 ## Custom Item Support
 

--- a/SemiSpoilerLogger/MajorItemTrackerModule.cs
+++ b/SemiSpoilerLogger/MajorItemTrackerModule.cs
@@ -91,6 +91,8 @@ namespace MajorItemByAreaTracker
         private bool IsWhiteFragment(string poolGroup, string itemName) => poolGroup == PoolGroup.Charms.FriendlyName()
             && itemName.IsOneOf(ItemNames.Queen_Fragment, ItemNames.King_Fragment, ItemNames.Void_Heart);
 
+        private bool IsGrub(string poolGroup, string itemName) => itemName == ItemNames.Grub;
+
         private bool IsKeyLikeCharm(string poolGroup, string itemName) => itemName.IsOneOf(ItemNames.Defenders_Crest, ItemNames.Spore_Shroom,
             ItemNames.Grimmchild1, ItemNames.Grimmchild2);
 
@@ -111,9 +113,10 @@ namespace MajorItemByAreaTracker
             string itemName = item.RandoItem()!.Name;
             SupplementalMetadata<AbstractItem> itemMeta = SupplementalMetadata.Of(item);
             string poolGroup = itemMeta.Get(InjectedProps.ItemPoolGroup);
-            return IsSkill(poolGroup, itemName)
-                || IsDreamer(poolGroup, itemName)
-                || IsWhiteFragment(poolGroup, itemName)
+            return (Config.IncludeSkills && IsSkill(poolGroup, itemName))
+                || (Config.IncludeDreamers && IsDreamer(poolGroup, itemName))
+                || (Config.IncludeWhiteFragments && IsWhiteFragment(poolGroup, itemName))
+                || (Config.IncludeGrubs && IsGrub(poolGroup, itemName))
                 || (Config.IncludeUniqueKeys && IsUniqueKey(poolGroup, itemName))
                 || (Config.IncludeSimpleKeys && IsSimpleKey(poolGroup, itemName))
                 || (Config.IncludeFragileCharms && IsFragileCharm(poolGroup, itemName))

--- a/SemiSpoilerLogger/MenuHolder.cs
+++ b/SemiSpoilerLogger/MenuHolder.cs
@@ -42,6 +42,7 @@ namespace MajorItemByAreaTracker
             ToggleButton enabledControl = (ToggleButton)mef.ElementLookup[nameof(MajorItemByAreaTracker.Instance.GS.Enabled)];
             enabledControl.SelfChanged += EnabledChanged;
             vip = new VerticalItemPanel(trackerPage, new(0, 300), 50f, true, mef.Elements);
+            AddCuteSpellingToggle((ToggleButton)mef.ElementLookup[nameof(MajorItemByAreaTracker.Instance.GS.IncludeGrubs)]);
             Localization.Localize(mef);
 
             jumpToTrackerButton = new SmallButton(connectionPage, Localization.Localize("All Major Items"));
@@ -68,6 +69,56 @@ namespace MajorItemByAreaTracker
         public void ApplySettingsToMenu(TrackerGlobalSettings settings)
         {
             mef.SetMenuValues(settings);
+        }
+
+        private void AddCuteSpellingToggle(ToggleButton button)
+        {
+            const int ClicksToToggle = 7;
+            const float ConsecutiveClickInterval = .5f;
+
+            // This should happen before the localization formatter is
+            // installed.
+            button.Formatter = new CuteSpellingFormatter(button.Formatter);
+            
+            int numConsecutiveClicks = 0;
+            float timeOfLastClick = float.NegativeInfinity;
+            button.OnClick += () =>
+            {
+                float now = UnityEngine.Time.time;
+                if (now - timeOfLastClick > ConsecutiveClickInterval)
+                {
+                    numConsecutiveClicks = 0;
+                }
+                timeOfLastClick = now;
+                numConsecutiveClicks++;
+                if (numConsecutiveClicks == ClicksToToggle)
+                {
+                    MajorItemByAreaTracker.Instance.GS.CuteSpelling = !MajorItemByAreaTracker.Instance.GS.CuteSpelling;
+                    // Trigger a text refresh, which will cause the
+                    // CuteSpellingFormatter to return a new string.
+                    button.Formatter = button.Formatter;
+                    numConsecutiveClicks = 0;
+                }
+            };
+        }
+    }
+
+    internal class CuteSpellingFormatter : MenuItemFormatter
+    {
+        private MenuItemFormatter orig;
+
+        public CuteSpellingFormatter(MenuItemFormatter orig)
+        {
+            this.orig = orig;
+        }
+
+        public override string GetText(string prefix, object value)
+        {
+            if (MajorItemByAreaTracker.Instance.GS.CuteSpelling)
+            {
+                return "Include Grubbies";
+            }
+            return orig.GetText(prefix, value);
         }
     }
 }

--- a/SemiSpoilerLogger/Settings/TrackerGlobalSettings.cs
+++ b/SemiSpoilerLogger/Settings/TrackerGlobalSettings.cs
@@ -31,6 +31,10 @@ namespace MajorItemByAreaTracker.Settings
         [HashModifier.HashIgnore]
         public UIDisplayType ShowUI { get; set; } = UIDisplayType.Always;
 
+        [MenuIgnore]
+        [HashModifier.HashIgnore]
+        public bool CuteSpelling { get; set; } = false;
+
         public TrackerSettings ToTrackerSettings()
         {
             return new()

--- a/SemiSpoilerLogger/Settings/TrackerGlobalSettings.cs
+++ b/SemiSpoilerLogger/Settings/TrackerGlobalSettings.cs
@@ -14,8 +14,6 @@ namespace MajorItemByAreaTracker.Settings
 
         public bool IncludeWhiteFragments { get; set; } = true;
 
-        public bool IncludeGrubs { get; set; } = false;
-
         public bool IncludeUniqueKeys { get; set; } = false;
 
         public bool IncludeSimpleKeys { get; set; } = false;
@@ -26,6 +24,8 @@ namespace MajorItemByAreaTracker.Settings
         public bool IncludeFragileCharms { get; set; } = false;
 
         public bool IncludeStags { get; set; } = false;
+
+        public bool IncludeGrubs { get; set; } = false;
 
         [MenuIgnore]
         [HashModifier.HashIgnore]
@@ -42,12 +42,12 @@ namespace MajorItemByAreaTracker.Settings
                 IncludeSkills = IncludeSkills,
                 IncludeDreamers = IncludeDreamers,
                 IncludeWhiteFragments = IncludeWhiteFragments,
-                IncludeGrubs = IncludeGrubs,
                 IncludeUniqueKeys = IncludeUniqueKeys,
                 IncludeSimpleKeys = IncludeSimpleKeys,
                 IncludeKeyLikeCharms = IncludeKeyLikeCharms,
                 IncludeFragileCharms = IncludeFragileCharms,
                 IncludeStags = IncludeStags,
+                IncludeGrubs = IncludeGrubs,
             };
         }
     }

--- a/SemiSpoilerLogger/Settings/TrackerGlobalSettings.cs
+++ b/SemiSpoilerLogger/Settings/TrackerGlobalSettings.cs
@@ -8,6 +8,14 @@ namespace MajorItemByAreaTracker.Settings
     {
         public bool Enabled { get; set; } = false;
 
+        public bool IncludeSkills { get; set; } = true;
+
+        public bool IncludeDreamers { get; set; } = true;
+
+        public bool IncludeWhiteFragments { get; set; } = true;
+
+        public bool IncludeGrubs { get; set; } = false;
+
         public bool IncludeUniqueKeys { get; set; } = false;
 
         public bool IncludeSimpleKeys { get; set; } = false;
@@ -27,6 +35,10 @@ namespace MajorItemByAreaTracker.Settings
         {
             return new()
             {
+                IncludeSkills = IncludeSkills,
+                IncludeDreamers = IncludeDreamers,
+                IncludeWhiteFragments = IncludeWhiteFragments,
+                IncludeGrubs = IncludeGrubs,
                 IncludeUniqueKeys = IncludeUniqueKeys,
                 IncludeSimpleKeys = IncludeSimpleKeys,
                 IncludeKeyLikeCharms = IncludeKeyLikeCharms,

--- a/SemiSpoilerLogger/Settings/TrackerSettings.cs
+++ b/SemiSpoilerLogger/Settings/TrackerSettings.cs
@@ -12,8 +12,6 @@ namespace MajorItemByAreaTracker.Settings
 
         public bool IncludeWhiteFragments { get; set; } = true;
 
-        public bool IncludeGrubs { get; set; } = false;
-
         public bool IncludeUniqueKeys { get; set; } = false;
 
         public bool IncludeSimpleKeys { get; set; } = false;
@@ -23,6 +21,8 @@ namespace MajorItemByAreaTracker.Settings
         public bool IncludeFragileCharms { get; set; } = false;
 
         public bool IncludeStags { get; set; } = false;
+
+        public bool IncludeGrubs { get; set; } = false;
 
         public Dictionary<string, int> ItemByNameCounter { get; set; } = new();
 

--- a/SemiSpoilerLogger/Settings/TrackerSettings.cs
+++ b/SemiSpoilerLogger/Settings/TrackerSettings.cs
@@ -4,6 +4,16 @@ namespace MajorItemByAreaTracker.Settings
 {
     public class TrackerSettings
     {
+        public bool IncludeMajorProgressionItems { get; set; } = true;
+
+        public bool IncludeSkills { get; set; } = true;
+
+        public bool IncludeDreamers { get; set; } = true;
+
+        public bool IncludeWhiteFragments { get; set; } = true;
+
+        public bool IncludeGrubs { get; set; } = false;
+
         public bool IncludeUniqueKeys { get; set; } = false;
 
         public bool IncludeSimpleKeys { get; set; } = false;

--- a/SemiSpoilerLogger/UI/TrackerUI.cs
+++ b/SemiSpoilerLogger/UI/TrackerUI.cs
@@ -137,10 +137,22 @@ namespace MajorItemByAreaTracker.UI
             TextObject? label = layout?.GetElement<TextObject>("Area Tracker Label");
             if (label != null)
             {
-                bool grubsOnly = model.ItemByNameCounter.Count == 1 && model.ItemByNameCounter.ContainsKey(ItemNames.Grub);
-                string mainLabel = grubsOnly ? "Grubs" : "Major Items";
-                label.Text = $"{mainLabel} Remaining ({total})";
+                label.Text = $"{MainLabel()} Remaining ({total})";
             }
+        }
+
+        private string MainLabel()
+        {
+            bool grubsOnly = model.ItemByNameCounter.Count == 1 && model.ItemByNameCounter.ContainsKey(ItemNames.Grub);
+            if (!grubsOnly)
+            {
+                return "Major Items";
+            }
+            if (MajorItemByAreaTracker.Instance.GS.CuteSpelling)
+            {
+                return "Grubbies";
+            }
+            return "Grubs";
         }
 
         public void Destroy()

--- a/SemiSpoilerLogger/UI/TrackerUI.cs
+++ b/SemiSpoilerLogger/UI/TrackerUI.cs
@@ -4,6 +4,7 @@ using MagicUI.Elements;
 using MajorItemByAreaTracker.Settings;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using ItemChanger;
 using RandomizerMod;
 using System.Collections.Generic;
 
@@ -136,7 +137,9 @@ namespace MajorItemByAreaTracker.UI
             TextObject? label = layout?.GetElement<TextObject>("Area Tracker Label");
             if (label != null)
             {
-                label.Text = $"Major Items Remaining ({total})";
+                bool grubsOnly = model.ItemByNameCounter.Count == 1 && model.ItemByNameCounter.ContainsKey(ItemNames.Grub);
+                string mainLabel = grubsOnly ? "Grubs" : "Major Items";
+                label.Text = $"{mainLabel} Remaining ({total})";
             }
         }
 

--- a/SemiSpoilerLogger/UI/TrackerUI.cs
+++ b/SemiSpoilerLogger/UI/TrackerUI.cs
@@ -137,11 +137,11 @@ namespace MajorItemByAreaTracker.UI
             TextObject? label = layout?.GetElement<TextObject>("Area Tracker Label");
             if (label != null)
             {
-                label.Text = $"{MainLabel()} Remaining ({total})";
+                label.Text = $"{GetMainLabel()} Remaining ({total})";
             }
         }
 
-        private string MainLabel()
+        private string GetMainLabel()
         {
             bool grubsOnly = model.ItemByNameCounter.Count == 1 && model.ItemByNameCounter.ContainsKey(ItemNames.Grub);
             if (!grubsOnly)


### PR DESCRIPTION
The first three options are enabled by default, matching the existing behaviour of the mod.

A small easter egg is available by repeatedly clicking the Include Grubs button.